### PR TITLE
[PS-16773] Added accessibility to tabs for Android

### DIFF
--- a/Tab.js
+++ b/Tab.js
@@ -69,7 +69,9 @@ export default class Tab extends React.Component {
         <TouchableNativeFeedback
           testID={this.props.testID}
           background={TouchableNativeFeedback.Ripple(undefined, true)}
-          onPress={this._handlePress}>
+          onPress={this._handlePress}
+          accessible={this.props.accessible}
+          accessibilityLabel={this.props.accessibilityLabel}>
           <View style={tabStyle}>
             <View>
               {icon}


### PR DESCRIPTION
Built to device  and used Android's Talk Back accessibility features to ensure the full tabs had the label and not just the icon.

Also used accessibility inspector on iOS to ensure no regression for iOS.