### PR TITLE
[PS-31383] add accessibility labels for custom tab renders

### DIFF
--- a/TabNavigator.js
+++ b/TabNavigator.js
@@ -101,7 +101,8 @@ export default class TabNavigator extends React.Component {
         <TouchableOpacity style={[styles.tabContainer, item.props.tabStyle]}
                           onPress={item.props.onPress}
                           activeOpacity={item.props.hidesTabTouch ? 1 : 0.8}
-                          accessible={false}>
+                          accessible={this.props.accessible}
+                          accessibilityLabel={this.props.accessibilityLabel}>
           {item.props.renderTab(item.props.selected)}
         </TouchableOpacity>
       );


### PR DESCRIPTION
Verified the accessibility label is now showing up correctly in appium.
<img width="1093" alt="Screen Shot 2020-12-17 at 2 08 28 PM" src="https://user-images.githubusercontent.com/22797037/102549840-ab0a6780-4071-11eb-83cc-a9c250bcabc3.png">
